### PR TITLE
Fix Go module version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module example.com/ocean
 
-go 1.24.3
+go 1.20
 
 require (
 	github.com/go-gl/gl v0.0.0-20231021071112-07e5d0ea2e71


### PR DESCRIPTION
## Summary
- fix go version in `go.mod`

## Testing
- `go mod tidy`

`docker` wasn't found so the container image couldn't be built.

------
https://chatgpt.com/codex/tasks/task_b_68763e3bf91c83208a753ff555e6c286