### PR TITLE
Fix Docker build command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 # Initialize module if needed
 RUN test -f go.mod || go mod init example.com/ocean
 RUN go mod tidy
-RUN CGO_ENABLED=1 go build -o ocean ocean_fft_glsl_go.go
+RUN CGO_ENABLED=1 go build -o ocean ./cmd/ocean-demo
 
 # Run stage
 FROM debian:bullseye-slim


### PR DESCRIPTION
## Summary
- correct the build target in Dockerfile to use the existing cmd directory

## Testing
- `go build ./cmd/ocean-demo`
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_687640061b4c83208f91b92e96396bad