### PR TITLE
Fix Docker build dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,13 @@ FROM golang:1.20 AS builder
 WORKDIR /app
 COPY . .
 
+# Install build dependencies for OpenGL bindings
+RUN apt-get update && \
+    apt-get install -y pkg-config libgl1-mesa-dev libx11-dev \
+                       libxi-dev libxcursor-dev libxrandr-dev \
+                       libxinerama-dev libxxf86vm-dev && \
+    rm -rf /var/lib/apt/lists/*
+
 # Initialize module if needed
 RUN test -f go.mod || go mod init example.com/ocean
 RUN go mod tidy


### PR DESCRIPTION
## Summary
- install required OpenGL dev libraries in the builder stage

## Testing
- `go build ./cmd/ocean-demo` *(fails: missing build environment dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6876426a76c0832084f4aeee1932793d