### PR TITLE
Add macOS binary builder

### DIFF
--- a/Dockerfile.mac
+++ b/Dockerfile.mac
@@ -1,0 +1,14 @@
+# syntax=docker/dockerfile:1
+
+# Build stage using xgo for Mac cross compilation
+FROM crazymax/xgo:latest AS builder
+
+WORKDIR /src
+COPY . .
+# Build the binary for macOS; ARCH can be overridden at build time
+ARG ARCH=amd64
+RUN xgo --targets=darwin/${ARCH} -out ocean-demo ./cmd/ocean-demo \
+    && mv ocean-demo-darwin*-${ARCH} /ocean-demo
+
+FROM scratch AS export
+COPY --from=builder /ocean-demo /ocean-demo

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+IMAGE ?= ocean-demo-mac
+ARCH ?= amd64
+CONTAINER ?= ocean-demo-build
+
+build:
+docker build --build-arg ARCH=$(ARCH) -f Dockerfile.mac -t $(IMAGE) .
+
+extract:
+docker create --name $(CONTAINER) $(IMAGE)
+docker cp $(CONTAINER):/ocean-demo ./ocean-demo
+docker rm $(CONTAINER)
+
+run: extract
+./ocean-demo
+
+.PHONY: build extract run


### PR DESCRIPTION
## Summary
- add a two-stage Dockerfile using xgo to cross compile for macOS
- add Makefile helpers to build the image, extract the binary, and run it

## Testing
- `go vet ./...` *(fails: X11 headers missing)*

------
https://chatgpt.com/codex/tasks/task_b_6876519ecf7c83208526e6126c747473