### PR TITLE
Fix Makefile command indentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,14 @@ ARCH ?= amd64
 CONTAINER ?= ocean-demo-build
 
 build:
-docker build --build-arg ARCH=$(ARCH) -f Dockerfile.mac -t $(IMAGE) .
+	docker build --build-arg ARCH=$(ARCH) -f Dockerfile.mac -t $(IMAGE) .
 
 extract:
-docker create --name $(CONTAINER) $(IMAGE)
-docker cp $(CONTAINER):/ocean-demo ./ocean-demo
-docker rm $(CONTAINER)
+	docker create --name $(CONTAINER) $(IMAGE)
+	docker cp $(CONTAINER):/ocean-demo ./ocean-demo
+	docker rm $(CONTAINER)
 
 run: extract
-./ocean-demo
+	./ocean-demo
 
 .PHONY: build extract run


### PR DESCRIPTION
## Summary
- ensure commands in Makefile start with a tab

## Testing
- `go test ./...`
- `make run` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_b_687653a9b81c832086ed3e3504d2c631