### PR TITLE
Improve Makefile build flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,13 @@ ARCH ?= amd64
 CONTAINER ?= ocean-demo-build
 
 build:
-	docker build --build-arg ARCH=$(ARCH) -f Dockerfile.mac -t $(IMAGE) .
+	@if ! docker image inspect $(IMAGE) > /dev/null 2>&1; then \
+	docker build --build-arg ARCH=$(ARCH) -f Dockerfile.mac -t $(IMAGE) .; \
+	else \
+	echo "$(IMAGE) image already exists"; \
+	fi
 
-extract:
+extract: build
 	docker create --name $(CONTAINER) $(IMAGE)
 	docker cp $(CONTAINER):/ocean-demo ./ocean-demo
 	docker rm $(CONTAINER)


### PR DESCRIPTION
## Summary
- update `build` to skip building if the docker image already exists
- make `extract` depend on `build`

## Testing
- `go vet ./...` *(fails: `X11/extensions/Xrandr.h` missing)*
- `go build ./...` *(fails: `X11/Xcursor/Xcursor.h` missing)*

------
https://chatgpt.com/codex/tasks/task_b_6876563ac6908320a2a10c7adcf0d2e7