### PR TITLE
Fix xgo build path

### DIFF
--- a/Dockerfile.mac
+++ b/Dockerfile.mac
@@ -7,7 +7,7 @@ WORKDIR /src
 COPY . .
 # Build the binary for macOS; ARCH can be overridden at build time
 ARG ARCH=amd64
-RUN xgo --targets=darwin/${ARCH} -out ocean-demo ./cmd/ocean-demo \
+RUN xgo --targets=darwin/${ARCH} --pkg cmd/ocean-demo -out ocean-demo . \
     && mv ocean-demo-darwin*-${ARCH} /ocean-demo
 
 FROM scratch AS export


### PR DESCRIPTION
## Summary
- make xgo aware of the macOS build package

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_b_68765c2acd548320a5fb37d801a2d732