### PR TITLE
Fix xgo output path

### DIFF
--- a/Dockerfile.mac
+++ b/Dockerfile.mac
@@ -8,7 +8,7 @@ COPY . .
 # Build the binary for macOS; ARCH can be overridden at build time
 ARG ARCH=amd64
 RUN xgo --targets=darwin/${ARCH} --pkg cmd/ocean-demo -out ocean-demo . \
-    && mv ocean-demo-darwin*-${ARCH} /ocean-demo
+    && mv /build/ocean-demo-darwin-${ARCH} /ocean-demo
 
 FROM scratch AS export
 COPY --from=builder /ocean-demo /ocean-demo


### PR DESCRIPTION
## Summary
- fix Mac Dockerfile to copy output from /build

## Testing
- `go build ./cmd/ocean-demo`

------
https://chatgpt.com/codex/tasks/task_b_68765fc454748320854e6a3c866f513a