### PR TITLE
Add separate container build step

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,3 @@
+# syntax=docker/dockerfile:1
+FROM crazymax/xgo:latest
+WORKDIR /src

--- a/readme.md
+++ b/readme.md
@@ -105,8 +105,9 @@ docker run --rm -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix ocean-demo
 `Makefile`, который собирает нативный бинарник внутри Docker.
 
 ```bash
-make build   # создаёт образ и собирает ./ocean-demo
-make run     # извлекает бинарник и запускает его
+make container  # собирает образ с окружением xgo (достаточно один раз)
+make build      # компилирует ./ocean-demo внутри контейнера
+make run        # запускает собранный бинарник
 ```
 
 Если всё же требуется запуск в контейнере, необходим XQuartz. После его старта


### PR DESCRIPTION
## Summary
- add a lightweight build environment `Dockerfile.build`
- update `Makefile` with `container` target and separate `build` step
- update docs with new make commands

## Testing
- `make container` *(fails: Cannot connect to the Docker daemon)*
- `make build` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_b_687664abd3588320b758db2933f4ab32