### PR TITLE
Fix quoting in Makefile build rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ container:
 	docker build -f Dockerfile.build -t $(BUILDER_IMAGE) .
 
 build:
-	docker run --rm -v $(PWD):/src $(BUILDER_IMAGE) \
-		bash -c "xgo --targets=darwin/${ARCH} --pkg cmd/ocean-demo -out ocean-demo . && mv /build/ocean-demo-darwin-${ARCH} /src/ocean-demo"
+docker run --rm -v $(PWD):/src $(BUILDER_IMAGE) \
+bash -c 'xgo --targets=darwin/${ARCH} --pkg cmd/ocean-demo -out ocean-demo . && mv /build/ocean-demo-darwin-${ARCH} /src/ocean-demo'
 
 run: build
 	./ocean-demo


### PR DESCRIPTION
## Summary
- fix quoting in Makefile so the build command runs properly inside the container

## Testing
- `go vet ./...` *(fails: Xcursor headers missing)*
- `go build ./...` *(fails: Xcursor headers missing)*

------
https://chatgpt.com/codex/tasks/task_b_6876cd446e9483208adb4c1f11bf042b