### PR TITLE
Fix Makefile build recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ container:
 	docker build -f Dockerfile.build -t $(BUILDER_IMAGE) .
 
 build:
-docker run --rm -v $(PWD):/src $(BUILDER_IMAGE) \
-bash -c 'xgo --targets=darwin/${ARCH} --pkg cmd/ocean-demo -out ocean-demo . && mv /build/ocean-demo-darwin-${ARCH} /src/ocean-demo'
+	docker run --rm -v $(PWD):/src $(BUILDER_IMAGE) \
+	bash -c 'xgo --targets=darwin/${ARCH} --pkg cmd/ocean-demo -out ocean-demo . && mv /build/ocean-demo-darwin-${ARCH} /src/ocean-demo'
 
 run: build
 	./ocean-demo


### PR DESCRIPTION
## Summary
- fix indentation for Makefile `build` recipe to ensure steps run

## Testing
- `make build` *(fails: docker missing)*
- `go test ./...` *(fails: missing X11 libs)*

------
https://chatgpt.com/codex/tasks/task_b_68775c82a7588320b2e7302c44305b87