### PR TITLE
Fix xgo docker run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ container:
 	docker build -f Dockerfile.build -t $(BUILDER_IMAGE) .
 
 build:
-	docker run --rm -v $(PWD):/src $(BUILDER_IMAGE) \
-	bash -c 'xgo --targets=darwin/${ARCH} --pkg cmd/ocean-demo -out ocean-demo . && mv /build/ocean-demo-darwin-${ARCH} /src/ocean-demo'
+       docker run --rm -v $(PWD):/src --entrypoint "" $(BUILDER_IMAGE) \
+       bash -c 'xgo --targets=darwin/$(ARCH) --pkg cmd/ocean-demo -out ocean-demo . && mv /build/ocean-demo-darwin-$(ARCH) /src/ocean-demo'
 
 run: build
 	./ocean-demo


### PR DESCRIPTION
## Summary
- fix Makefile build target to clear xgo's entrypoint

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(no output, no tests)*

------
https://chatgpt.com/codex/tasks/task_b_68775df27f7c8320bac517c911ec88e0