### PR TITLE
Fix Makefile build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ container:
 	docker build -f Dockerfile.build -t $(BUILDER_IMAGE) .
 
 build:
-       docker run --rm -v $(PWD):/src --entrypoint "" $(BUILDER_IMAGE) \
-       bash -c 'xgo --targets=darwin/$(ARCH) --pkg cmd/ocean-demo -out ocean-demo . && mv /build/ocean-demo-darwin-$(ARCH) /src/ocean-demo'
+	docker run --rm -v $(PWD):/src --entrypoint "" $(BUILDER_IMAGE) \
+	bash -c 'xgo --targets=darwin/$(ARCH) --pkg cmd/ocean-demo -out ocean-demo . && mv /build/ocean-demo-darwin-$(ARCH) /src/ocean-demo'
 
 run: build
 	./ocean-demo


### PR DESCRIPTION
## Summary
- fix indentation for `build` target so `make build` runs

## Testing
- `go test ./...` *(fails: Xcursor headers missing)*
- `go vet ./...` *(fails: Xcursor headers missing)*

------
https://chatgpt.com/codex/tasks/task_b_68776133c470832090c7781e39a4bd51