### PR TITLE
Fix macOS OpenGL context creation

### DIFF
--- a/cmd/ocean-demo/main.go
+++ b/cmd/ocean-demo/main.go
@@ -23,6 +23,8 @@ func main() {
 	glfw.WindowHint(glfw.ContextVersionMajor, 3)
 	glfw.WindowHint(glfw.ContextVersionMinor, 3)
 	glfw.WindowHint(glfw.OpenGLProfile, glfw.OpenGLCoreProfile)
+	// macOS requires forward-compatible contexts for OpenGL 3.2+
+	glfw.WindowHint(glfw.OpenGLForwardCompatible, glfw.True)
 	glfw.WindowHint(glfw.Resizable, glfw.True)
 
 	window, err := glfw.CreateWindow(1280, 720, "Ocean FFT Demo", nil, nil)


### PR DESCRIPTION
## Summary
- set the `glfw.OpenGLForwardCompatible` hint

## Testing
- `go build ./...` *(fails: X11/Xcursor/Xcursor.h: No such file or directory)*
- `go vet ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_b_68777cd15fa883209bdcc1133dbe3557